### PR TITLE
[bugfix][alias] fix conditional check failure: invalid syntax

### DIFF
--- a/roles/ip-alias/tasks/main.yml
+++ b/roles/ip-alias/tasks/main.yml
@@ -13,4 +13,4 @@
 - name: Bring up alias interface
   shell: >
     ifup {{ alias_device }}
-  when: "'{{ alias_device }}' not in '{{ ipa_output.stdout }}'"
+  when: "alias_device not in ipa_output.stdout"


### PR DESCRIPTION
hit one issue when running enb.yaml playbook, where the conditional check failed with invalid syntax error, detailed log as below:

## log start ##
TASK [ip-alias : Bring up alias interface] ********************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: '{{ alias_device }}' not in
'{{ ipa_output.stdout_lines }}'

fatal: [enb-host]: FAILED! => {"failed": true, "msg": "The conditional check ''{{ alias_device }}' not in '{{ ipa_output.stdout_lines }}'' failed. The error was: Invalid conditional detected: invalid syntax (<unknown>, line 1)\n\nThe error appears to have been in '/root/oai-ansible/roles/ip-alias/tasks/main.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Bring up alias interface\n  ^ here\n"}
## log end ##

fix it by removing the '{}' since the condition is already in quotes, it's safe to remove them.
tested on my environment, it works. (I'm using ansible version 2.3.1.0)